### PR TITLE
Lable Change ios.js

### DIFF
--- a/ios.js
+++ b/ios.js
@@ -9,8 +9,8 @@
  * @param {('unbalanced'|'ios11'|'ios11-fixed-diameter')} [options.extended = false] - Whether to include intermediate circles in the first half (for 'unbalanced') or in the first and last third (for 'ios11') (original and Step-choice only). If 'ios11-fixed-diameter', the circles will have a fixed diameter, and the number of circles has to be 11.
  * @param {boolean} [options.unbalanced = false] - If true, there are twice as many circles in the first half (original and Step-choice only)
  * @param {boolean} [options.ios11 = false] - If true, there are twice as many circles in the first and last third, inspired by IOS11 (original and Step-choice only)
- * @param {string} [options.you = 'You'] - String for the left circle
- * @param {string} [options.other = 'Other'] - String for the right circle
+ * @param {string} [options.children = 'Children'] - String for the left circle
+ * @param {string} [options.parents = 'Parents'] - String for the right circle
  * @param {string} [options.buttonsClass = ''] - Additional class to pass to the buttons: circles if using original IOS, arrows if using Step-choice IOS
  * @param {('column' | 'row')} [options.direction = 'column'] - Arrangement of the buttons, if using original IOS
  * @param {number} [options.leftTextWidth = 40] - Size reserved for string of left circle, needs to be adjusted manually until the initial pair of circles has no overlap
@@ -27,8 +27,8 @@ function Ios({
     numberCircles = 7,
     circleDiameter = 100,
     extended = false,
-    you = 'You',
-    other = 'Other',
+    children = 'Children',
+    parents = 'Parents',
     buttonsClass = '',
     direction = 'column',
     leftTextWidth = 40,


### PR DESCRIPTION
Hi, I am a student currently working on a research project that involves implementing the continuous Inclusion of Other in the Self (IOS) scale using your excellent ios-js library.
I am reaching out to kindly ask whether there is a recommended method for customizing the default text labels on the two circles — specifically, replacing “You” and “Other” with customed labels. I have reviewed the documentation and explored the JavaScript code, but I am unsure of the best practice for making this modification in a way that preserves functionality and compatibility.
If there is a parameter, function, or customization method you would recommend, I would be very grateful for your guidance.
Thank you for your time, and for making this tool publicly available — it’s been incredibly helpful for our study.
Warm regards